### PR TITLE
Fix connection error to Casa Node on Firefox

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -28,6 +28,12 @@
     "scripts": ["background.js"],
     "persistent": true
   },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "addon@keys.casa",
+      "strict_min_version": "42.0"
+    }
+  },
   "web_accessible_resources": ["*.js", "*.html"],
-  "permissions": ["storage", "activeTab", "clipboardWrite", "contextMenus"]
+  "permissions": ["http://casa-node.local/", "http://localhost:3000/", "storage", "activeTab", "clipboardWrite", "contextMenus"]
 }


### PR DESCRIPTION
Fix connection error to Casa Node on Firefox by requesting user permissions for relevant URLs.